### PR TITLE
Add  use-context sub command

### DIFF
--- a/pkg/pi/cmd/config/config.go
+++ b/pkg/pi/cmd/config/config.go
@@ -68,7 +68,7 @@ func NewCmdConfig(pathOptions *clientcmd.PathOptions, out, errOut io.Writer) *co
 	//cmd.AddCommand(NewCmdConfigSet(out, pathOptions))
 	//cmd.AddCommand(NewCmdConfigUnset(out, pathOptions))
 	cmd.AddCommand(NewCmdConfigCurrentContext(out, pathOptions))
-	//cmd.AddCommand(NewCmdConfigUseContext(out, pathOptions))
+	cmd.AddCommand(NewCmdConfigUseContext(out, pathOptions))
 	cmd.AddCommand(NewCmdConfigGetContexts(out, pathOptions))
 	//cmd.AddCommand(NewCmdConfigGetClusters(out, pathOptions))
 	//cmd.AddCommand(NewCmdConfigDeleteCluster(out, pathOptions))


### PR DESCRIPTION
If using many gcp zone, or having many access key/secret, we need to switch context.