### PR TITLE
support 'pi logs'

### DIFF
--- a/pkg/pi/cmd/cmd.go
+++ b/pkg/pi/cmd/cmd.go
@@ -232,6 +232,7 @@ func NewPiCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cobra.Co
 			Message: "Troubleshooting and Debugging Commands:",
 			Commands: []*cobra.Command{
 				//NewCmdDescribe(f, out, err),
+				NewCmdLogs(f, out),
 				NewCmdExec(f, in, out, err),
 			},
 		},

--- a/pkg/pi/cmd/cmd.go
+++ b/pkg/pi/cmd/cmd.go
@@ -231,7 +231,7 @@ func NewPiCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cobra.Co
 		{
 			Message: "Troubleshooting and Debugging Commands:",
 			Commands: []*cobra.Command{
-				//NewCmdDescribe(f, out, err),
+				NewCmdDescribe(f, out, err),
 				NewCmdLogs(f, out),
 				NewCmdExec(f, in, out, err),
 			},

--- a/pkg/pi/cmd/describe.go
+++ b/pkg/pi/cmd/describe.go
@@ -79,7 +79,7 @@ func NewCmdDescribe(f cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {
 	argAliases := pi.ResourceAliases(validArgs)
 
 	cmd := &cobra.Command{
-		Use:     "describe (-f FILENAME | TYPE [NAME_PREFIX | -l label] | TYPE/NAME)",
+		Use:     "describe (TYPE [NAME_PREFIX | -l label] | TYPE/NAME)",
 		Short:   i18n.T("Show details of a specific resource or group of resources"),
 		Long:    describeLong + "\n\n" + cmdutil.ValidResourceTypeList(f),
 		Example: describeExample,
@@ -90,10 +90,10 @@ func NewCmdDescribe(f cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {
 		ValidArgs:  validArgs,
 		ArgAliases: argAliases,
 	}
-	usage := "containing the resource to describe"
-	cmdutil.AddFilenameOptionFlags(cmd, options, usage)
+	//usage := "containing the resource to describe"
+	//cmdutil.AddFilenameOptionFlags(cmd, options, usage)
 	cmd.Flags().StringP("selector", "l", "", "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
-	cmd.Flags().Bool("all-namespaces", false, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
+	//cmd.Flags().Bool("all-namespaces", false, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
 	cmd.Flags().BoolVar(&describerSettings.ShowEvents, "show-events", true, "If true, display events related to the described object.")
 	cmdutil.AddIncludeUninitializedFlag(cmd)
 	return cmd
@@ -101,14 +101,14 @@ func NewCmdDescribe(f cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {
 
 func RunDescribe(f cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, args []string, options *resource.FilenameOptions, describerSettings *printers.DescriberSettings) error {
 	selector := cmdutil.GetFlagString(cmd, "selector")
-	allNamespaces := cmdutil.GetFlagBool(cmd, "all-namespaces")
-	cmdNamespace, enforceNamespace, err := f.DefaultNamespace()
+	//allNamespaces := cmdutil.GetFlagBool(cmd, "all-namespaces")
+	cmdNamespace, _, err := f.DefaultNamespace()
 	if err != nil {
 		return err
 	}
-	if allNamespaces {
-		enforceNamespace = false
-	}
+	//if allNamespaces {
+	//	enforceNamespace = false
+	//}
 	if len(args) == 0 && cmdutil.IsFilenameSliceEmpty(options.Filenames) {
 		fmt.Fprint(cmdErr, "You must specify the type of resource to describe. ", cmdutil.ValidResourceTypeList(f))
 		return cmdutil.UsageErrorf(cmd, "Required resource not specified.")
@@ -120,8 +120,8 @@ func RunDescribe(f cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, a
 	r := f.NewBuilder().
 		Unstructured().
 		ContinueOnError().
-		NamespaceParam(cmdNamespace).DefaultNamespace().AllNamespaces(allNamespaces).
-		FilenameParam(enforceNamespace, options).
+		NamespaceParam(cmdNamespace).DefaultNamespace(). //AllNamespaces(allNamespaces).
+		//FilenameParam(enforceNamespace, options).
 		LabelSelectorParam(selector).
 		IncludeUninitialized(includeUninitialized).
 		ResourceTypeOrNameArgs(true, args...).

--- a/pkg/pi/cmd/describe.go
+++ b/pkg/pi/cmd/describe.go
@@ -49,14 +49,8 @@ var (
 		exists, it will output details for every resource that has a name prefixed with NAME_PREFIX.`)
 
 	describeExample = templates.Examples(i18n.T(`
-		# Describe a node
-		pi describe nodes kubernetes-node-emt8.c.myproject.internal
-
 		# Describe a pod
 		pi describe pods/nginx
-
-		# Describe a pod identified by type and name in "pod.json"
-		pi describe -f pod.json
 
 		# Describe all pods
 		pi describe pods
@@ -64,9 +58,11 @@ var (
 		# Describe pods by label name=myLabel
 		pi describe po -l name=myLabel
 
-		# Describe all pods managed by the 'frontend' replication controller (rc-created pods
-		# get the name of the rc as a prefix in the pod the name).
-		pi describe pods frontend`))
+		# Describe a service
+		pi describe service my-service
+
+		# Describe a secret
+		pi describe secret my-secret`))
 )
 
 func NewCmdDescribe(f cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {
@@ -81,7 +77,7 @@ func NewCmdDescribe(f cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "describe (TYPE [NAME_PREFIX | -l label] | TYPE/NAME)",
 		Short:   i18n.T("Show details of a specific resource or group of resources"),
-		Long:    describeLong + "\n\n" + cmdutil.ValidResourceTypeList(f),
+		Long:    describeLong + "\n\n" + cmdutil.ValidDescribeResourceTypeList(f) + "\n",
 		Example: describeExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunDescribe(f, out, cmdErr, cmd, args, options, describerSettings)
@@ -110,7 +106,7 @@ func RunDescribe(f cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, a
 	//	enforceNamespace = false
 	//}
 	if len(args) == 0 && cmdutil.IsFilenameSliceEmpty(options.Filenames) {
-		fmt.Fprint(cmdErr, "You must specify the type of resource to describe. ", cmdutil.ValidResourceTypeList(f))
+		fmt.Fprint(cmdErr, "You must specify the type of resource to describe. ", cmdutil.ValidDescribeResourceTypeList(f), "\n")
 		return cmdutil.UsageErrorf(cmd, "Required resource not specified.")
 	}
 

--- a/pkg/pi/cmd/logs.go
+++ b/pkg/pi/cmd/logs.go
@@ -1,0 +1,253 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"errors"
+	"io"
+	"math"
+	"os"
+	"time"
+
+	restclient "github.com/hyperhq/client-go/rest"
+	"github.com/hyperhq/pi/pkg/pi/cmd/templates"
+	cmdutil "github.com/hyperhq/pi/pkg/pi/cmd/util"
+	"github.com/hyperhq/pi/pkg/pi/util"
+	"github.com/hyperhq/pi/pkg/pi/util/i18n"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/apis/core/validation"
+)
+
+var (
+	logsExample = templates.Examples(i18n.T(`
+		# Return snapshot logs from pod mongo with only one container
+		pi logs mongo
+
+		# Return snapshot logs for the pods defined by label app=mongo
+		pi logs -lapp=mongo
+
+		# Return snapshot of previous terminated mongo container logs from pod mongo
+		pi logs -c mongo mongo
+
+		# Begin streaming the logs of the mongo container in pod mongo
+		pi logs -f -c mongo mongo
+
+		# Display only the most recent 10 lines of output in pod mongo
+		pi logs --tail=10 mongo
+
+		# Show all logs from pod mongo written in the last hour
+		pi logs --since=1h mongo`))
+
+	selectorTail int64 = 10
+)
+
+const (
+	logsUsageStr = "expected 'logs (POD | TYPE/NAME) [CONTAINER_NAME]'.\nPOD or TYPE/NAME is a required argument for the logs command"
+)
+
+type LogsOptions struct {
+	Namespace   string
+	ResourceArg string
+	Options     runtime.Object
+
+	Mapper  meta.RESTMapper
+	Typer   runtime.ObjectTyper
+	Decoder runtime.Decoder
+
+	Object        runtime.Object
+	GetPodTimeout time.Duration
+	LogsForObject func(object, options runtime.Object, timeout time.Duration) (*restclient.Request, error)
+
+	Out io.Writer
+}
+
+// NewCmdLogs creates a new pod logs command
+func NewCmdLogs(f cmdutil.Factory, out io.Writer) *cobra.Command {
+	o := &LogsOptions{}
+	cmd := &cobra.Command{
+		Use:     "logs [-f] (POD | TYPE/NAME) [-c CONTAINER]",
+		Short:   i18n.T("Print the logs for a container in a pod"),
+		Long:    "Print the logs for a container in a pod. If the pod has only one container, the container name is optional.",
+		Example: logsExample,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			if len(os.Args) > 1 && os.Args[1] == "log" {
+				printDeprecationWarning("logs", "log")
+			}
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(o.Complete(f, out, cmd, args))
+			cmdutil.CheckErr(o.Validate())
+			cmdutil.CheckErr(o.RunLogs())
+		},
+		Aliases: []string{"log"},
+	}
+	cmd.Flags().BoolP("follow", "f", false, "Specify if the logs should be streamed.")
+	cmd.Flags().Bool("timestamps", false, "Include timestamps on each line in the log output")
+	cmd.Flags().Int64("limit-bytes", 0, "Maximum bytes of logs to return. Defaults to no limit.")
+	cmd.Flags().BoolP("previous", "p", false, "If true, print the logs for the previous instance of the container in a pod if it exists.")
+	cmd.Flags().Int64("tail", -1, "Lines of recent log file to display. Defaults to -1 with no selector, showing all log lines otherwise 10, if a selector is provided.")
+	cmd.Flags().String("since-time", "", i18n.T("Only return logs after a specific date (RFC3339). Defaults to all logs. Only one of since-time / since may be used."))
+	cmd.Flags().Duration("since", 0, "Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs. Only one of since-time / since may be used.")
+	cmd.Flags().StringP("container", "c", "", "Print the logs of this container")
+	//cmd.Flags().Bool("interactive", false, "If true, prompt the user for input when required.")
+	//cmd.Flags().MarkDeprecated("interactive", "This flag is no longer respected and there is no replacement.")
+	cmdutil.AddPodRunningTimeoutFlag(cmd, defaultPodLogsTimeout)
+	cmd.Flags().StringP("selector", "l", "", "Selector (label query) to filter on.")
+	return cmd
+}
+
+func (o *LogsOptions) Complete(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string) error {
+	containerName := cmdutil.GetFlagString(cmd, "container")
+	selector := cmdutil.GetFlagString(cmd, "selector")
+	switch len(args) {
+	case 0:
+		if len(selector) == 0 {
+			return cmdutil.UsageErrorf(cmd, "%s", logsUsageStr)
+		}
+	case 1:
+		o.ResourceArg = args[0]
+		if len(selector) != 0 {
+			return cmdutil.UsageErrorf(cmd, "only a selector (-l) or a POD name is allowed")
+		}
+	case 2:
+		if cmd.Flag("container").Changed {
+			return cmdutil.UsageErrorf(cmd, "only one of -c or an inline [CONTAINER] arg is allowed")
+		}
+		o.ResourceArg = args[0]
+		containerName = args[1]
+	default:
+		return cmdutil.UsageErrorf(cmd, "%s", logsUsageStr)
+	}
+	var err error
+	o.Namespace, _, err = f.DefaultNamespace()
+	if err != nil {
+		return err
+	}
+
+	logOptions := &api.PodLogOptions{
+		Container:  containerName,
+		Follow:     cmdutil.GetFlagBool(cmd, "follow"),
+		Previous:   cmdutil.GetFlagBool(cmd, "previous"),
+		Timestamps: cmdutil.GetFlagBool(cmd, "timestamps"),
+	}
+	if sinceTime := cmdutil.GetFlagString(cmd, "since-time"); len(sinceTime) > 0 {
+		t, err := util.ParseRFC3339(sinceTime, metav1.Now)
+		if err != nil {
+			return err
+		}
+		logOptions.SinceTime = &t
+	}
+	if limit := cmdutil.GetFlagInt64(cmd, "limit-bytes"); limit != 0 {
+		logOptions.LimitBytes = &limit
+	}
+	tail := cmdutil.GetFlagInt64(cmd, "tail")
+	if tail != -1 {
+		logOptions.TailLines = &tail
+	}
+	if sinceSeconds := cmdutil.GetFlagDuration(cmd, "since"); sinceSeconds != 0 {
+		// round up to the nearest second
+		sec := int64(math.Ceil(float64(sinceSeconds) / float64(time.Second)))
+		logOptions.SinceSeconds = &sec
+	}
+	o.GetPodTimeout, err = cmdutil.GetPodRunningTimeoutFlag(cmd)
+	if err != nil {
+		return err
+	}
+	o.Options = logOptions
+	o.LogsForObject = f.LogsForObject
+	o.Out = out
+
+	if len(selector) != 0 {
+		if logOptions.Follow {
+			return cmdutil.UsageErrorf(cmd, "only one of follow (-f) or selector (-l) is allowed")
+		}
+		if logOptions.TailLines == nil && tail != -1 {
+			logOptions.TailLines = &selectorTail
+		}
+	}
+
+	if o.Object == nil {
+		builder := f.NewBuilder().
+			Internal().
+			NamespaceParam(o.Namespace).DefaultNamespace().
+			SingleResourceType()
+		if o.ResourceArg != "" {
+			builder.ResourceNames("pods", o.ResourceArg)
+		}
+		if selector != "" {
+			builder.ResourceTypes("pods").LabelSelectorParam(selector)
+		}
+		infos, err := builder.Do().Infos()
+		if err != nil {
+			return err
+		}
+		if selector == "" && len(infos) != 1 {
+			return errors.New("expected a resource")
+		}
+		o.Object = infos[0].Object
+	}
+
+	return nil
+}
+
+func (o LogsOptions) Validate() error {
+	logsOptions, ok := o.Options.(*api.PodLogOptions)
+	if !ok {
+		return errors.New("unexpected logs options object")
+	}
+	if errs := validation.ValidatePodLogOptions(logsOptions); len(errs) > 0 {
+		return errs.ToAggregate()
+	}
+
+	return nil
+}
+
+// RunLogs retrieves a pod log
+func (o LogsOptions) RunLogs() error {
+	switch t := o.Object.(type) {
+	case *api.PodList:
+		for _, p := range t.Items {
+			if err := o.getLogs(&p); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return o.getLogs(o.Object)
+	}
+}
+
+func (o LogsOptions) getLogs(obj runtime.Object) error {
+	req, err := o.LogsForObject(obj, o.Options, o.GetPodTimeout)
+	if err != nil {
+		return err
+	}
+
+	readCloser, err := req.Stream()
+	if err != nil {
+		return err
+	}
+	defer readCloser.Close()
+
+	_, err = io.Copy(o.Out, readCloser)
+	return err
+}

--- a/pkg/pi/cmd/resource/get.go
+++ b/pkg/pi/cmd/resource/get.go
@@ -139,7 +139,7 @@ func NewCmdGet(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Comman
 	cmd.Flags().StringVarP(&options.LabelSelector, "selector", "l", options.LabelSelector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	//cmd.Flags().StringVar(&options.FieldSelector, "field-selector", options.FieldSelector, "Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.")
 	//cmd.Flags().BoolVar(&options.AllNamespaces, "all-namespaces", options.AllNamespaces, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
-	//cmdutil.AddIncludeUninitializedFlag(cmd)
+	cmdutil.AddIncludeUninitializedFlag(cmd)
 	cmdutil.AddPrinterFlags(cmd)
 	//addOpenAPIPrintColumnFlags(cmd)
 	//cmd.Flags().BoolVar(&options.ShowKind, "show-kind", options.ShowKind, "If present, list the resource type for the requested object(s).")

--- a/pkg/pi/cmd/util/factory_object_mapping.go
+++ b/pkg/pi/cmd/util/factory_object_mapping.go
@@ -231,6 +231,8 @@ func (f *ring1Factory) LogsForObject(object, options runtime.Object, timeout tim
 	var namespace string
 	switch t := object.(type) {
 	case *api.Pod:
+		t.Namespace = "default"
+		glog.V(4).Infof("namespace:%v podName:%v opts:%v", t.Namespace, t.Name, opts)
 		return clientset.Core().Pods(t.Namespace).GetLogs(t.Name, opts), nil
 
 	case *api.ReplicationController:

--- a/pkg/pi/cmd/util/printing.go
+++ b/pkg/pi/cmd/util/printing.go
@@ -204,6 +204,17 @@ func ValidDeleteResourceTypeList(f ClientAccessFactory) string {
 	`)
 }
 
+func ValidDescribeResourceTypeList(f ClientAccessFactory) string {
+	// TODO: Should attempt to use the cached discovery list or fallback to a static list
+	// that is calculated from code compiled into the factory.
+	return templates.LongDesc(`Valid resource types include:
+
+			* pods (aka 'po')
+			* secrets
+			* services (aka 'svc')
+	`)
+}
+
 func ValidNameResourceTypeList(f ClientAccessFactory) string {
 	// TODO: Should attempt to use the cached discovery list or fallback to a static list
 	// that is calculated from code compiled into the factory.


### PR DESCRIPTION
```
$ pi logs mongo --tail=5
2018-04-23T02:43:59.482+0000 I STORAGE  [thread1] createCollection: config.system.sessions with generated UUID: fefbb769-4437-48fd-a17c-bcfcebe400bf
2018-04-23T02:43:59.611+0000 I INDEX    [thread1] build index on: config.system.sessions properties: { v: 2, key: { lastUse: 1 }, name: "lsidTTLIndex", ns: "config.system.sessions", expireAfterSeconds: 1800 }
2018-04-23T02:43:59.616+0000 I INDEX    [thread1] 	 building index using bulk method; build may temporarily use up to 500 megabytes of RAM
2018-04-23T02:43:59.624+0000 I INDEX    [thread1] build index done.  scanned 0 total records. 0 secs
2018-04-23T02:43:59.626+0000 I COMMAND  [thread1] command config.$cmd command: createIndexes { createIndexes: "system.sessions", indexes: [ { key: { lastUse: 1 }, name: "lsidTTLIndex", expireAfterSeconds: 1800 } ], $db: "config" } numYields:0 reslen:98 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, Database: { acquireCount: { W: 1 } }, Collection: { acquireCount: { w: 1 } } } protocol:op_msg 144ms
```

```
$ pi describe pods busybox
...
Tolerations:     <none>
Events:
  Type    Reason                 Age   From               Message
  ----    ------                 ----  ----               -------
  Normal  PortCreated            4m    pod-watcher        Successfully created port "pod-busybox"
  Normal  Scheduled              4m    default-scheduler  Successfully assigned busybox to compute node b-1
  Normal  SuccessfulMountVolume  4m    kubelet, b-1       MountVolume.SetUp succeeded for volume "default-token-72qvw"
  Normal  PortSynced             4m    port-controller    Successfully synced port "pod-busybox"
  Normal  Pulled                 4m    kubelet, b-1       Container image "busybox" already present on machine
  Normal  Created                4m    kubelet, b-1       Created container
  Normal  Started                4m    kubelet, b-1       Started container
```